### PR TITLE
Fix request completion time calculation

### DIFF
--- a/request.py
+++ b/request.py
@@ -41,7 +41,13 @@ class Request:
     
     # saves time from lift arrival to request completion (time spent in the lift)
     def floor_check_in(self, time: float):
-        self.time_in_lift = time - self.time_on_floor
+        # ``time_on_floor`` stores the waiting time from request creation until
+        # the lift arrives.  To get the duration spent inside the lift we need
+        # to subtract both the waiting time and the creation time from the
+        # completion timestamp.  Previously the creation time was ignored,
+        # leading to inflated in-lift times when the simulation start time was
+        # not zero.
+        self.time_in_lift = time - self.time_created - self.time_on_floor
         return True
     
     # creates a list of all floor numbers between two specified floors based on the direction of the lift


### PR DESCRIPTION
## Summary
- correct request completion time logic: time spent in lift now excludes waiting time and request creation timestamp

## Testing
- `python -m py_compile *.py`
- `python - <<'PY'
from request import Request
req = Request(request_floor=1, target_floor=5, time_created=3.2)
req.lift_check_in(5.2)
req.floor_check_in(20.2)
print('time_on_floor:', req.time_on_floor)
print('time_in_lift:', req.time_in_lift)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6894d0816eec8326bfaf099e21a059a8